### PR TITLE
Tuned pipeline scripts

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       TAG: ${{ github.sha }}
     steps:

--- a/.github/workflows/version-bump-up/version-bump-up.py
+++ b/.github/workflows/version-bump-up/version-bump-up.py
@@ -148,7 +148,7 @@ def pushToOpeninsight(newManifest, newReadme, newCbility):
     # sha = branch.raw_data['object']['sha']
 
     openinsightRepo.update_file('builder/otelcol-builder.yaml',
-                                'update otelcol-builder.yaml to latest version',
+                                'update otelcol-builder.yaml to {0}'.format(latestVersion),
                                 dump(newManifest, Dumper=RoundTripDumper, width=float("inf")),
                                 openinsightRepo.get_contents('builder/otelcol-builder.yaml', ref).sha,
                                 branchName)


### PR DESCRIPTION
1. make auto upstream version bump PR's commit message more understandable.
2. scale-up timeout-minutes in the release-packages pipeline to fix timeout.